### PR TITLE
Integrate RabbitMQ message queue for gauge updates

### DIFF
--- a/OdectyStat/Application/GaugeService.cs
+++ b/OdectyStat/Application/GaugeService.cs
@@ -21,7 +21,7 @@ namespace OdectyMVC.Application
             var gauge = await context.GaugeRepository.GetGauge(newValue.GaugeId);
             gauge.SetNewValue(newValue.Value, newValue.Datetime);
             await context.SaveChangesAsync();
-
+            await context.MessageQueue.Publish(new { gaugeId = newValue.GaugeId, value = gauge.LastValue }, "odecty.gauge.lastvaluechanged");
             var service = new ComputeService3(context);
             var result = await service.Compute(newValue.GaugeId);
             context.AddRange(result);

--- a/OdectyStat/Application/GaugeService.cs
+++ b/OdectyStat/Application/GaugeService.cs
@@ -3,6 +3,7 @@ using OdectyStat;
 using OdectyStat.Business;
 using OdectyStat.Dto;
 using OdectyStat1.Business;
+using OdectyStat1.Dto;
 
 namespace OdectyMVC.Application
 {
@@ -21,7 +22,7 @@ namespace OdectyMVC.Application
             var gauge = await context.GaugeRepository.GetGauge(newValue.GaugeId);
             gauge.SetNewValue(newValue.Value, newValue.Datetime);
             await context.SaveChangesAsync();
-            await context.MessageQueue.Publish(new { gaugeId = newValue.GaugeId, value = gauge.LastValue }, "odecty.gauge.lastvaluechanged");
+            await context.MessageQueue.Publish(new { gaugeId = newValue.GaugeId, value = gauge.LastValue }, MessageQueueRoutingKeys.Odecty_Gauge_Lastvaluechanged);
             var service = new ComputeService3(context);
             var result = await service.Compute(newValue.GaugeId);
             context.AddRange(result);

--- a/OdectyStat/Contracts/IGaugeContext.cs
+++ b/OdectyStat/Contracts/IGaugeContext.cs
@@ -13,6 +13,8 @@ namespace OdectyMVC.Contracts
         IMeasurementRepository MeasurementRepository { get; }
         IHomeAssistantStatisticsRepository HomeAssistantStatisticsRepository { get; }
 
+        IMessageQueue MessageQueue { get; }
+
         void AddHomeAssistant<TEntity>(TEntity entity);
         void AddRange<TEntity>(ICollection<TEntity> entities);
         Task SaveChangesAsync();

--- a/OdectyStat/Contracts/IMessageQueue.cs
+++ b/OdectyStat/Contracts/IMessageQueue.cs
@@ -4,6 +4,6 @@ namespace OdectyMVC.Contracts
 {
     public interface IMessageQueue
     {
-        Task Publish(int gaugeId);
+        Task Publish(object message, string routingKey);
     }
 }

--- a/OdectyStat/DataLayer/GaugeContext.cs
+++ b/OdectyStat/DataLayer/GaugeContext.cs
@@ -19,7 +19,8 @@ namespace OdectyMVC.DataLayer
             IMeasurementStatisticsRepository measurementStatisticsRepository,
             IMeasurementRepository measurementRepository,
             IHomeAssistantStatisticsRepository homeAssistantStatisticsRepository,
-            HomeAssistantDbContext homeAssistantDbContext)
+            HomeAssistantDbContext homeAssistantDbContext,
+            IMessageQueue messageQueue)
         {
             GaugeRepository=gaugeRepository;
             this.context=context;
@@ -29,6 +30,7 @@ namespace OdectyMVC.DataLayer
             MeasurementRepository=measurementRepository;
             HomeAssistantStatisticsRepository=homeAssistantStatisticsRepository;
             this.homeAssistantDbContext=homeAssistantDbContext;
+            MessageQueue = messageQueue;
         }
 
         public IGaugeRepository GaugeRepository { get; }
@@ -40,6 +42,7 @@ namespace OdectyMVC.DataLayer
         public IMeasurementRepository MeasurementRepository { get; }
 
         public IHomeAssistantStatisticsRepository HomeAssistantStatisticsRepository { get; }
+        public IMessageQueue MessageQueue { get; }
 
         public void AddHomeAssistant<TEntity>(TEntity entity)
         {

--- a/OdectyStat/DataLayer/MessageQueue.cs
+++ b/OdectyStat/DataLayer/MessageQueue.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.Extensions.Options;
+using OdectyMVC.Contracts;
+using OdectyStat1.Dto;
+using RabbitMQ.Client;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OdectyStat1.DataLayer;
+public class MessageQueue : IMessageQueue
+{
+    private readonly IModel model;
+    private readonly IOptions<OdectySettings> options;
+
+    public MessageQueue(RabbitMQProvider rabbitMQProvider, IOptions<OdectySettings> options)
+    {
+        model = rabbitMQProvider.CreateModel();
+    }
+    public Task Publish(object message, string routingKey)
+    {
+        model.BasicPublish(exchange: options.Value.ExchangeName,
+                             routingKey: routingKey,
+                             basicProperties: null,
+                             body: Encoding.UTF8.GetBytes(System.Text.Json.JsonSerializer.Serialize(message)));
+        return Task.CompletedTask;
+    }
+}

--- a/OdectyStat/DataLayer/MessageQueue.cs
+++ b/OdectyStat/DataLayer/MessageQueue.cs
@@ -17,6 +17,7 @@ public class MessageQueue : IMessageQueue
     public MessageQueue(RabbitMQProvider rabbitMQProvider, IOptions<OdectySettings> options)
     {
         model = rabbitMQProvider.CreateModel();
+        this.options = options;
     }
     public Task Publish(object message, string routingKey)
     {

--- a/OdectyStat/DataLayer/RabbitMQProvider.cs
+++ b/OdectyStat/DataLayer/RabbitMQProvider.cs
@@ -1,0 +1,50 @@
+﻿using Microsoft.Extensions.Options;
+using OdectyStat1.Dto;
+using RabbitMQ.Client;
+
+namespace OdectyStat1.DataLayer;
+public class RabbitMQProvider : IDisposable
+{
+    private readonly IConnection connection;
+    private readonly IOptions<OdectySettings> options;
+
+    public RabbitMQProvider(IOptions<OdectySettings> options)
+    {
+        var factory = new ConnectionFactory();
+        factory.HostName = options.Value.RabbitMQHost;
+        factory.UserName = options.Value.RabbitMQUsername;
+        factory.Password = options.Value.RabbitMQPassword;
+        factory.VirtualHost = options.Value.RabbitMQVHost;
+
+        connection = factory.CreateConnection();
+        this.options = options;
+    }
+
+    public IModel CreateModel()
+    {
+        var model = connection.CreateModel();
+        model.ExchangeDeclare(options.Value.ExchangeName, ExchangeType.Direct, true, false, null);
+        foreach (var exchange in options.Value.QueueMappings.Select(q => q.ExchangeName).Distinct())
+        {
+            if (exchange.StartsWith("amq."))
+            {
+                continue;
+            }
+            model.ExchangeDeclare(exchange, ExchangeType.Direct, true, false, null);
+        }
+        foreach (var queue in options.Value.QueueMappings.Select(q => q.QueueName).Distinct())
+        {
+            model.QueueDeclare(queue, true, false, false, null);
+        }
+        foreach (var map in options.Value.QueueMappings)
+        {
+            model.QueueBind(map.QueueName, map.ExchangeName, map.RoutingKey);
+        }
+        return model;
+    }
+
+    public void Dispose()
+    {
+        connection?.Close();
+    }
+}

--- a/OdectyStat/Dto/MessageQueueRoutingKeys.cs
+++ b/OdectyStat/Dto/MessageQueueRoutingKeys.cs
@@ -1,0 +1,12 @@
+﻿using Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OdectyStat1.Dto;
+public static class MessageQueueRoutingKeys
+{
+    public const string Odecty_Gauge_Lastvaluechanged = "odecty.gauge.lastvaluechanged";
+}

--- a/OdectyStat/Dto/OdectySettings.cs
+++ b/OdectyStat/Dto/OdectySettings.cs
@@ -10,8 +10,7 @@ public class OdectySettings
     public string RabbitMQHost { get; set; }
     public string RabbitMQUsername { get; set; }
     public string RabbitMQPassword { get; set; }
-    public string RabbitMQQueue { get; set; }
     public string RabbitMQVHost { get; set; }
-
+    public string ExchangeName { get; set; }
     public List<QueueMapping> QueueMappings { get; set; }
 }

--- a/OdectyStat/Program.cs
+++ b/OdectyStat/Program.cs
@@ -25,11 +25,12 @@ await Host.CreateDefaultBuilder()
     .ConfigureServices((hostContext, services) =>
      {
          services.Configure<OdectySettings>(hostContext.Configuration.GetSection("OdectySettings"));
+         services.AddSingleton<RabbitMQProvider>();
          services.AddScoped<IGaugeContext, GaugeContext>();
          services.AddScoped<IGaugeRepository, GaugeRepository>();
          services.AddScoped<IMeasurementDayRepository, MeasurementDayRepository>();
          services.AddScoped<IGaugeService, GaugeService>();
-         //services.AddScoped<IExcelProvider, ExcelProvider>();
+         services.AddScoped<IMessageQueue, MessageQueue>();
          services.AddScoped<IMeasurementRepository, MeasurementRepository>();
          services.AddScoped<IMeasurementStatisticsRepository, MeasurementStatisticsRepository>();
          services.AddScoped<IHomeAssistantStatisticsRepository, HomeAssistantStatisticsRepository>();


### PR DESCRIPTION
Added IMessageQueue to IGaugeContext and implemented MessageQueue and RabbitMQProvider for RabbitMQ integration. GaugeService now publishes gauge value changes to the message queue. Refactored MQClient to use RabbitMQProvider and updated configuration to support exchange names and queue mappings. Registered new services in Program.cs.