### PR TITLE
Refactor RabbitMQ consumers to use shared base class

### DIFF
--- a/OdectyStat/DataLayer/Consumers/ConsumerBackgroundService.cs
+++ b/OdectyStat/DataLayer/Consumers/ConsumerBackgroundService.cs
@@ -17,7 +17,8 @@ public class ConsumerBackgroundService : BackgroundService
     }
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        while (!stoppingToken.IsCancellationRequested)
+        bool stopRequired = false;
+        while (!stopRequired)
         {
             foreach (var consumer in serviceProvider.GetServices<IRabbitMQConsumer>())
             {
@@ -25,9 +26,14 @@ public class ConsumerBackgroundService : BackgroundService
                 {
                     consumer.StartConsuming();
                 }
+                if (stoppingToken.IsCancellationRequested)
+                {
+                    consumer.StopConsuming();
+                }
             }
             // Placeholder for background service logic
             await Task.Delay(1000, stoppingToken);
+            stopRequired = stoppingToken.IsCancellationRequested;
         }
     }
 }

--- a/OdectyStat/DataLayer/Consumers/ConsumerBackgroundService.cs
+++ b/OdectyStat/DataLayer/Consumers/ConsumerBackgroundService.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OdectyStat1.DataLayer.Consumers;
+public class ConsumerBackgroundService : BackgroundService
+{
+    private readonly IServiceProvider serviceProvider;
+
+    public ConsumerBackgroundService(IServiceProvider serviceProvider)
+    {
+        this.serviceProvider = serviceProvider;
+    }
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            foreach (var consumer in serviceProvider.GetServices<IRabbitMQConsumer>())
+            {
+                if (!consumer.IsConsuming)
+                {
+                    consumer.StartConsuming();
+                }
+            }
+            // Placeholder for background service logic
+            await Task.Delay(1000, stoppingToken);
+        }
+    }
+}

--- a/OdectyStat/DataLayer/Consumers/IRabbitMQConsumer.cs
+++ b/OdectyStat/DataLayer/Consumers/IRabbitMQConsumer.cs
@@ -1,0 +1,10 @@
+﻿namespace OdectyStat1.DataLayer.Consumers;
+
+public interface IRabbitMQConsumer
+{
+    bool IsConsuming { get; }
+
+    void Dispose();
+    void StartConsuming();
+    void StopConsuming();
+}

--- a/OdectyStat/DataLayer/Consumers/RabbitMQConsumer.cs
+++ b/OdectyStat/DataLayer/Consumers/RabbitMQConsumer.cs
@@ -1,0 +1,75 @@
+﻿using Microsoft.Extensions.Logging;
+using RabbitMQ.Client;
+using RabbitMQ.Client.Events;
+
+namespace OdectyStat1.DataLayer.Consumers;
+public abstract class RabbitMQConsumer : IDisposable, IRabbitMQConsumer
+{
+    private readonly RabbitMQProvider rabbitMQProvider;
+    private readonly ILogger<RabbitMQConsumer> logger;
+    private readonly string queueName;
+    private IModel model;
+
+    public bool IsConsuming => model != null && !model.IsClosed;
+
+    public RabbitMQConsumer(RabbitMQProvider rabbitMQProvider, ILogger<RabbitMQConsumer> logger, string queueName)
+    {
+        this.rabbitMQProvider = rabbitMQProvider;
+        this.rabbitMQProvider.ConnectionShutdown += (s, e) =>
+        {
+            StopConsuming();
+            logger.LogWarning("RabbitMQ connection shutdown detected. Stopped consuming.");
+        };
+        this.logger = logger;
+        this.queueName = queueName;
+    }
+
+    public void StartConsuming()
+    {
+        if (model == null || model.IsClosed)
+        {
+            model = rabbitMQProvider.CreateModel();
+            model.ModelShutdown += (s, e) =>
+            {
+                StopConsuming();
+                logger.LogWarning("RabbitMQ model shutdown detected. Stopped consuming from queue: {QueueName}", queueName);
+            };
+        }
+        if (model == null)
+        {
+            logger.LogWarning("Failed to create RabbitMQ model for consuming.");
+            StopConsuming();
+            return;
+        }
+        var consumer = new EventingBasicConsumer(model);
+        consumer.Received += ConsumerReceived;
+        model.BasicConsume(queueName, false, consumer);
+        logger.LogInformation("Started consuming from queue: {QueueName}", queueName);
+    }
+
+    protected abstract void ConsumerReceived(object? sender, BasicDeliverEventArgs e);
+
+    protected void AcknowledgeMessage(ulong deliveryTag)
+    {
+        model?.BasicAck(deliveryTag, false);
+    }
+
+    protected void RejectMessage(ulong deliveryTag, bool requeue = false)
+    {
+        model?.BasicReject(deliveryTag, requeue);
+    }
+
+    public void StopConsuming()
+    {
+        model?.Close();
+        model?.Dispose();
+        model = null;
+    }
+
+    public void Dispose()
+    {
+        model?.Close();
+        model?.Dispose();
+        model = null;
+    }
+}

--- a/OdectyStat/DataLayer/RabbitMQProvider.cs
+++ b/OdectyStat/DataLayer/RabbitMQProvider.cs
@@ -1,28 +1,81 @@
-﻿using Microsoft.Extensions.Options;
+﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using OdectyStat1.Dto;
 using RabbitMQ.Client;
 
 namespace OdectyStat1.DataLayer;
 public class RabbitMQProvider : IDisposable
 {
-    private readonly IConnection connection;
+    private IConnection connection;
     private readonly IOptions<OdectySettings> options;
+    private readonly ILogger<RabbitMQProvider> logger;
     private bool first = true;
+    private readonly ConnectionFactory factory;
+    private bool isConnected = false;
+    private TimeSpan mqttConnectionTimeout = TimeSpan.Zero;
+    private readonly Random random = new Random();
+    private DateTime? lastAttemptTime = null;
+    private TimeSpan? connectionDelay = null;
 
-    public RabbitMQProvider(IOptions<OdectySettings> options)
+    public EventHandler ConnectionShutdown = new EventHandler((s, e) => { });
+
+    public RabbitMQProvider(IOptions<OdectySettings> options, ILogger<RabbitMQProvider> logger)
     {
-        var factory = new ConnectionFactory();
+        factory = new ConnectionFactory();
         factory.HostName = options.Value.RabbitMQHost;
         factory.UserName = options.Value.RabbitMQUsername;
         factory.Password = options.Value.RabbitMQPassword;
         factory.VirtualHost = options.Value.RabbitMQVHost;
-
-        connection = factory.CreateConnection();
         this.options = options;
+        this.logger = logger;
+    }
+
+    private void Connect()
+    {
+        if(lastAttemptTime.HasValue && connectionDelay.HasValue  && (DateTime.Now - lastAttemptTime.Value) < connectionDelay || connection != null)
+        {
+            return;
+        }
+        try
+        {
+            connection = factory.CreateConnection();
+            connection.ConnectionShutdown += Connection_ConnectionShutdown;
+            isConnected = true;
+            logger.LogInformation("Successfully connected to RabbitMQ at {HostName}", factory.HostName);
+            lastAttemptTime = null;
+            connectionDelay = null;
+            return;
+        }
+        catch (Exception ex)
+        {
+            isConnected = false;
+            lastAttemptTime = DateTime.Now;
+            connectionDelay = mqttConnectionTimeout = TimeSpan.FromMilliseconds(Math.Min(mqttConnectionTimeout.TotalMilliseconds * 2 + random.Next(0, 5000), 300000));
+
+            logger.LogWarning(ex, "Failed to connect to RabbitMQ at {HostName}, retrying in {Delay}ms)",
+                factory.HostName, connectionDelay.Value.TotalMilliseconds);
+        }
+    }
+
+
+    private void Connection_ConnectionShutdown(object? sender, ShutdownEventArgs e)
+    {
+        connection?.Close();
+        connection?.Dispose();
+        connection = null;
+        isConnected = false;
     }
 
     public IModel CreateModel()
     {
+        if(!isConnected)
+        {
+            Connect();
+        }
+        if(!isConnected)
+        {
+            return null;
+        }
         if (first)
         {
             using var model = connection.CreateModel();
@@ -51,5 +104,6 @@ public class RabbitMQProvider : IDisposable
     public void Dispose()
     {
         connection?.Close();
+        connection = null;
     }
 }

--- a/OdectyStat/Program.cs
+++ b/OdectyStat/Program.cs
@@ -39,9 +39,10 @@ await Host.CreateDefaultBuilder()
          {
              opt.UseNpgsql(hostContext.Configuration.GetConnectionString("HomeAssistant"));
          })
-         .AddHostedService<MQClient>()
-         .AddHostedService<RecognizedSuccess>()
-         .AddHostedService<RecognizedFailed>();
+         .AddHostedService<ConsumerBackgroundService>()
+         .AddSingleton<IRabbitMQConsumer, MQClient>()
+         .AddSingleton<IRabbitMQConsumer, RecognizedSuccess>()
+         .AddSingleton<IRabbitMQConsumer, RecognizedFailed>();
      })
     .ConfigureLogging(logging =>
     {


### PR DESCRIPTION
Introduced a new abstract RabbitMQConsumer base class and IRabbitMQConsumer interface to unify and simplify consumer logic. Replaced BackgroundService inheritance in MQClient, RecognizedSuccess, and RecognizedFailed with RabbitMQConsumer, moving common message handling and connection logic to the base class. Added ConsumerBackgroundService to manage consumer lifecycles, and updated dependency injection in Program.cs to use singleton consumers. Improved RabbitMQProvider with connection retry and shutdown handling.