### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,9 @@ on:
     branches: [ "main" ]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/Zefek/Odecty/security/code-scanning/2](https://github.com/Zefek/Odecty/security/code-scanning/2)

Add an explicit `permissions` block to `.github/workflows/build.yml` at the workflow root (recommended here since there is only one job).  
For this workflow, the minimal required permission is:

- `contents: read` (needed by `actions/checkout`)

No additional token scopes are required for `upload-artifact` (artifact upload uses the Actions service and does not require repository write scope).  
Place the block between `on:` and `jobs:` so it applies to all jobs unless overridden.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
